### PR TITLE
redefinedAnnotations

### DIFF
--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/tearDown.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/tearDown.st
@@ -4,6 +4,6 @@ tearDown
 	Here we clear redefining state which forces cache reset"
 	| redefiningAnnotation |
 	redefiningAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
-	redefiningAnnotation class resetRedefiningInstances.
+	redefiningAnnotation class revertRedefinedInstances.
 	
 	super tearDown.

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/tearDown.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/tearDown.st
@@ -1,0 +1,9 @@
+running
+tearDown
+	"Some tests redefine following annotation. 
+	Here we clear redefining state which forces cache reset"
+	| redefiningAnnotation |
+	redefiningAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	redefiningAnnotation class resetRedefiningInstances.
+	
+	super tearDown.

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/tearDown.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/tearDown.st
@@ -2,8 +2,7 @@ running
 tearDown
 	"Some tests redefine following annotation. 
 	Here we clear redefining state which forces cache reset"
-	| redefiningAnnotation |
-	redefiningAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
-	redefiningAnnotation class revertRedefinedInstances.
+	ClassAnnotationExample3 revertRedefinedInstances.
+	"ClassAnnotationExample3 = ClassWithSingleAnnotation classAnnotations anyOne class"
 	
 	super tearDown.

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testForgettingAnnotation.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testForgettingAnnotation.st
@@ -1,0 +1,8 @@
+tests
+testForgettingAnnotation
+	| annotation |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	
+	ClassAnnotation registry forgetAnnotation: annotation.
+	
+	self assert: ClassWithSingleAnnotation classAnnotations isEmpty

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingAllRedefinedInstances.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingAllRedefinedInstances.st
@@ -1,0 +1,9 @@
+tests
+testGettingAllRedefinedInstances
+	| annotation allRedefined |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	annotation redefineBy: [ annotation priority: -1000 ].
+
+	allRedefined := annotation class redefinedInstances.	
+	self assert: allRedefined size equals: 1.
+	self assert: allRedefined anyOne priority equals: 0

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingAllRedefinedInstancesShouldCleanGarbage.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingAllRedefinedInstancesShouldCleanGarbage.st
@@ -1,0 +1,10 @@
+tests
+testGettingAllRedefinedInstancesShouldCleanGarbage
+	| annotation allRedefined |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	annotation redefineBy: [ annotation priority: -1000 ].
+	
+	ClassAnnotation registry forgetAnnotation: annotation.
+	
+	allRedefined := annotation class redefinedInstances.	
+	self assert: allRedefined isEmpty

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingAllRedefiningInstances.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingAllRedefiningInstances.st
@@ -1,0 +1,10 @@
+tests
+testGettingAllRedefiningInstances
+	| annotation allRedefining |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	annotation redefineBy: [ annotation priority: -1000 ].
+
+	allRedefining := annotation class redefiningInstances.	
+	self assert: allRedefining size equals: 1.
+	self assert: allRedefining anyOne priority equals: -1000.
+	self assert: allRedefining anyOne == annotation

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingAllRedefiningInstancesShouldCleanGarbage.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingAllRedefiningInstancesShouldCleanGarbage.st
@@ -1,0 +1,10 @@
+tests
+testGettingAllRedefiningInstancesShouldCleanGarbage
+	| annotation allRedefined |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	annotation redefineBy: [ annotation priority: -1000 ].
+	
+	ClassAnnotation registry forgetAnnotation: annotation.
+	
+	allRedefined := annotation class redefiningInstances.	
+	self assert: allRedefined isEmpty

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingRedefinedInstance.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingRedefinedInstance.st
@@ -1,0 +1,10 @@
+tests
+testGettingRedefinedInstance
+	| annotation redefinedInstance |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	annotation redefineBy: [ annotation priority: -1000 ].
+	
+	redefinedInstance := annotation redefinedInstance.
+	self deny: redefinedInstance == annotation.
+	self assert: redefinedInstance priority equals: 0.
+	self assert: redefinedInstance isRedefined

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingRedefiningInstance.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingRedefiningInstance.st
@@ -1,0 +1,9 @@
+tests
+testGettingRedefiningInstance
+	| annotation actual |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	annotation redefineBy: [ annotation priority: -1000 ].
+	
+	actual := annotation copy redefiningInstance.
+	
+	self assert: actual == annotation

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingSingleAnnotationUsingSelector.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testGettingSingleAnnotationUsingSelector.st
@@ -1,0 +1,9 @@
+tests
+testGettingSingleAnnotationUsingSelector
+	| expected actual |
+	
+	expected := ClassWithThreeAnnotations classAnnotations 
+		detect: [ :each | each declarationSelector = #annotationExample2 ].
+	actual := ClassWithThreeAnnotations classAnnotationAt: #annotationExample2.
+	
+	self assert: actual == expected

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testObsolete.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testObsolete.st
@@ -1,0 +1,9 @@
+tests
+testObsolete
+	| annotation |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	self deny: annotation isObsolete.
+	
+	ClassAnnotation registry forgetAnnotation: annotation.
+	
+	self assert: annotation isObsolete

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstance.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstance.st
@@ -1,0 +1,13 @@
+tests
+testRedefiningInstance
+	| annotation newAnnotation |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	self halt.
+	annotation redefineBy: [ annotation priority: -1000 ].
+	self assert: annotation priority equals: -1000.
+	self assert: annotation isRedefined.
+	
+	ClassAnnotation resetAll.
+	newAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	self assert: newAnnotation priority equals: -1000.
+	self assert: newAnnotation isRedefined

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstance.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstance.st
@@ -2,12 +2,12 @@ tests
 testRedefiningInstance
 	| annotation newAnnotation |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
-	self halt.
+	
 	annotation redefineBy: [ annotation priority: -1000 ].
 	self assert: annotation priority equals: -1000.
 	self assert: annotation isRedefined.
 	
-	ClassAnnotation resetAll.
+	ClassAnnotation resetCache.
 	newAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	self assert: newAnnotation priority equals: -1000.
 	self assert: newAnnotation isRedefined

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstanceTwice.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstanceTwice.st
@@ -1,0 +1,14 @@
+tests
+testRedefiningInstanceTwice
+	| annotation newAnnotation reverted |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	
+	annotation redefineBy: [ annotation priority: -1000 ].
+	annotation redefineBy: [ annotation priority: -2000 ].
+	
+	ClassAnnotation resetCache.
+	newAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	self assert: newAnnotation priority equals: -2000.
+	newAnnotation revertRedefinedInstance.
+	reverted := ClassWithSingleAnnotation classAnnotations anyOne.
+	self assert: reverted priority equals: 0.

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstanceTwice.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstanceTwice.st
@@ -4,7 +4,9 @@ testRedefiningInstanceTwice
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	
 	annotation redefineBy: [ annotation priority: -1000 ].
+	self assert: annotation redefinedInstance priority equals: 0.
 	annotation redefineBy: [ annotation priority: -2000 ].
+	self assert: annotation redefinedInstance priority equals: 0.
 	
 	ClassAnnotation resetCache.
 	newAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstanceUsingBlockWithArgument.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRedefiningInstanceUsingBlockWithArgument.st
@@ -1,0 +1,10 @@
+tests
+testRedefiningInstanceUsingBlockWithArgument
+	| newAnnotation |
+	
+	ClassWithSingleAnnotation classAnnotations anyOne
+		redefineBy: [:annotation | annotation priority: -1000 ].
+		
+	newAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	self assert: newAnnotation priority equals: -1000.
+	self assert: newAnnotation isRedefined

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRevertingAllRedefinedInstances.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRevertingAllRedefinedInstances.st
@@ -1,0 +1,8 @@
+tests
+testRevertingAllRedefinedInstances
+	| annotation |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	annotation class revertRedefinedInstances.
+	
+	self assert: annotation class redefinedInstances isEmpty.
+	self assert: annotation class redefiningInstances isEmpty

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRevertingRedefinedInstance.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRevertingRedefinedInstance.st
@@ -3,9 +3,9 @@ testRevertingRedefinedInstance
 	| annotation revertedAnnotation |
 	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
 	annotation redefineBy: [ annotation priority: -1000 ].
-	annotation revertRedefinedInstance.
-	
-	revertedAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	revertedAnnotation := annotation revertRedefinedInstance.
+
+	self deny: revertedAnnotation == annotation.	
+	self assert: revertedAnnotation == ClassWithSingleAnnotation classAnnotations anyOne.
 	self assert: revertedAnnotation priority equals: 0.
-	self deny: revertedAnnotation isRedefined.
-	self deny: revertedAnnotation == annotation
+	self deny: revertedAnnotation isRedefined

--- a/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRevertingRedefinedInstance.st
+++ b/ClassAnnotation-Tests.package/ClassAnnotationTests.class/instance/testRevertingRedefinedInstance.st
@@ -1,0 +1,11 @@
+tests
+testRevertingRedefinedInstance
+	| annotation revertedAnnotation |
+	annotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	annotation redefineBy: [ annotation priority: -1000 ].
+	annotation revertRedefinedInstance.
+	
+	revertedAnnotation := ClassWithSingleAnnotation classAnnotations anyOne.
+	self assert: revertedAnnotation priority equals: 0.
+	self deny: revertedAnnotation isRedefined.
+	self deny: revertedAnnotation == annotation

--- a/ClassAnnotation-Tests.package/RegisteredClassAnnotationsTests.class/instance/setUp.st
+++ b/ClassAnnotation-Tests.package/RegisteredClassAnnotationsTests.class/instance/setUp.st
@@ -2,4 +2,4 @@ running
 setUp
 	super setUp.
 	
-	ClassAnnotation resetAll
+	ClassAnnotation resetCache

--- a/ClassAnnotation-Tests.package/RegisteredClassAnnotationsTests.class/instance/tearDown.st
+++ b/ClassAnnotation-Tests.package/RegisteredClassAnnotationsTests.class/instance/tearDown.st
@@ -1,6 +1,6 @@
 running
 tearDown
 		
-	ClassAnnotation resetAll.
+	ClassAnnotation resetCache.
 	
 	super tearDown.

--- a/ClassAnnotation.package/Class.extension/instance/classAnnotationAt..st
+++ b/ClassAnnotation.package/Class.extension/instance/classAnnotationAt..st
@@ -1,0 +1,4 @@
+*ClassAnnotation
+classAnnotationAt: selector
+	^self classAnnotations 
+		detect: [ :each | each declarationSelector = selector ]

--- a/ClassAnnotation.package/ClassAnnotation.class/README.md
+++ b/ClassAnnotation.package/ClassAnnotation.class/README.md
@@ -1,26 +1,33 @@
 I am the root of class annotation hierarchy.
 My subclasses should annotate classes using class side methods with the pragma #classAnnotation. 
 For example:
+
 	MyClass class>>specialAnnotationExample
 		<classAnnotation>
 		^MySpecialAnnotation new
+
 The annotating method should return an instance of the annotation.
 
 I provide a query API to retrieve all registered instances of a concrete annotation class:
-	MySpecialAnnotation registeredInstances
-	MySpecialAnnotation registeredInstancesFor: MyClass
+
+	MySpecialAnnotation registeredInstances.
+	MySpecialAnnotation registeredInstancesFor: MyClass.
 	MySpecialAnnotation registeredInstancesDo: [:each | each logCr].
+
 Each annotation includes the annotated class and the selector of declaration method.
 All annotations are cached in default ClassAnnotationRegistry instance. It is cheap to query them.
 
 Classes itself can be queried for all attached annotations:
-	MyClass classAnnotations
-	MyClass classAnnotationsDo: [:each | each logCr]
+
+	MyClass classAnnotations.
+	MyClass classAnnotationsDo: [:each | each logCr].
 
 I provide extra hook to forbid annotating of particular classes. For example my subclasses can define that abstract classses should not be annotated by them.
 The rule should be  implemented in the method:
+
 	MySpecialAnnotation >>isForbidden
 		^annotatedClass isAbstract 
+
 By default method returns true which means that annotation can annotate any class.
 
 Because annotations are declared in the methods it provides interesting feature to extend meta information from external packages.
@@ -43,34 +50,49 @@ Any annotation can be contextual. You can specify instance of context where anno
 Context describes annotation users where they should be active.
 
 For simplicity you can specify any class instead of context instance. It will represent all users of annotation of particular class hierarchy:
-	MySpecialAnnotation for: MyUserClass
+
+	MySpecialAnnotation for: MyUserClass.
+
 Internallly argument is always converted to the context:
-	MyUserClass asAnnotationContext
+
+	MyUserClass asAnnotationContext.
+
 I provide query interface to retriev registered annotations which are active in given context:
-	MySpecialAnnotation activeInstancesInContext: anAnnotationUser
-	MySpecialAnnotation activeInstancesInContext: anAnnotationUser do: [:ann | ]
-	MySpecialAnnotation activeInstancesFor: MyClass inContext: anAnnotationUser do: [:ann | ]
+
+	MySpecialAnnotation activeInstancesInContext: anAnnotationUser.
+	MySpecialAnnotation activeInstancesInContext: anAnnotationUser do: [:ann | ].
+	MySpecialAnnotation activeInstancesFor: MyClass inContext: anAnnotationUser do: [:ann | ].
+
 By default the annotation is active if given user is described by declared context:
+
 	ClassAnnotation>>isActiveInContext: anAnnotationUser
 		^activeContext describes: anAnnotationUser
+
 Subclasses can provide extra conditions for active annotations. In that case they override this method:
+
 	MySpecialAnnotation>>isActiveInContext: anAnnotationUser
 		^(super isActiveInContext: anAnnotationUser)
 			and: [annotatingClass canBeUsedInContext: anAnnotationUser]
+
 So the logic can depends on annotating class itself and actual annotation user.
 
 For some scenarios you may need to query annotations according to original "active" definition despite of extra conditions.
 For such cases I introduced the "visibility" of annotations: the annotation is visible if it is declared for given user:
+
 	ClassAnnotation>>isVisibleInContext: anAnnotationUser
 		^activeContext describes: anAnnotationUser
+
 So the visible annotation is not necessary active. But active annotation is always visible for given user:
+
 	ClassAnnotation>>isActiveInContext: anAnnotationUser
 		^self isVisibleInContext: anAnnotationUser
+
 (I showed another version above to simplify description).
 There are extra query methods to retrieve visible annotations:
-	MySpecialAnnotation visibleInstancesInContext: anAnnotationUser
-	MySpecialAnnotation visibleInstancesInContext: anAnnotationUser do: [:ann | ]
-	MySpecialAnnotation visibleInstancesFor: MyClass inContext: anAnnotationUser do: [:ann | ]
+
+	MySpecialAnnotation visibleInstancesInContext: anAnnotationUser.
+	MySpecialAnnotation visibleInstancesInContext: anAnnotationUser do: [:ann | ].
+	MySpecialAnnotation visibleInstancesFor: MyClass inContext: anAnnotationUser do: [:ann | ].
 
 -----------Advanced features. Annotation dependency methods------------
 
@@ -90,10 +112,70 @@ For example in Commander package there is CmdShortcutCommandActivation annotatio
 This annotation will keep cmd+r in instance variable. 
 If you will modify #renamingFor: method with new shorctut the annotations should be updated. And special pragma ensures this logic:
 
-	CmdShortcutCommandActivation class>> renamingFor: anAnnotationUser
+	CmdShortcutCommandActivation class>>renamingFor: anAnnotationUser
 		<classAnnotationDependency>
 		^self by: $r meta for: anAnnotationUser 
-  
+
+-----------Advanced features. Redefining registered instances------------
+
+All annotations are collected from methods and cached in default ClassAnnotationRegistry instance. 
+I provide special mechanizm to redefine collected instances. When cache is updated I use and keep all redefined annotations.
+
+To redefine particular annotation use #redefineBy: message with block which sets custom properties to original instance.
+For example following code allows to redefine shortcut of #browse command in Calypso: 
+
+	(ClySpawnFullBrowserCommand classAnnotationsAt: #browserShortcutActivation)
+		redefineBy: [:shortcut | shortcut keyCombination: $o meta ].
+	
+Try evaluate it and press cmd+o on selected item in browser. If will open new browser window.
+You can notice that old shortcut cmd+b is not working anymore.
+
+Now you can manualy reset annotation cache to check that it will not affect redefined shortcut: 
+
+	ClassAnnotation resetCache.
+	
+To inspect redefined annotations ask their class for: 
+
+	CmdShortcutCommandActivation redefinedInstances
+	
+Redefined instances are stored in class side variable #redefinedInstances. 
+It is a dictionary which keys are new redefining annotations and values are original annotations collected from methods.
+Notice that key and value are equal objects because annotations define equality using annotated class and declaration selector.
+So dictionary items can be accessed using both objects.
+
+To check that annotation is redefined use following example: 
+
+	 (ClySpawnFullBrowserCommand classAnnotationsAt: #browserShortcutActivation)
+			isRedefined
+
+And you can ask actual redefined annotaion: 
+
+	 (ClySpawnFullBrowserCommand classAnnotationsAt: #browserShortcutActivation)
+			redefinedInstance
+		
+Using annotation instance you can also retrieve redefining instance: 
+
+	anAnnotation redefiningInstance.
+	
+It should be identical to cached one.
+	
+To revert redefined annotation use #revertRedefinedInstance message: 
+
+	(ClySpawnFullBrowserCommand classAnnotationsAt: #browserShortcutActivation)
+			revertRedefinedInstance
+
+Check that now browse command is again activated by cmd+b shortcut (which is defined in annotation declaration method).
+
+To revert all annotations use following script: 
+
+	CmdShortcutCommandActivation revertRedefinedInstances
+
+Redefining logic is very suitable mehanizm to override system behavior which depends on annotations without changing the code.
+It can be used to manage particular kind of annotation in settings browser. 
+For example shortcut annotations based on Commander are available in setting browser. Users can explore and edit all shortcuts in the system. And these settings are persistable.
+
+-----------Internal Representation and Key Implementation Points------------
+ 
     Instance Variables
 	annotatedClass:		<Class>
 	declarationSelector:		<Symbol>

--- a/ClassAnnotation.package/ClassAnnotation.class/class/cleanRedefinedGarbage.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/cleanRedefinedGarbage.st
@@ -1,0 +1,11 @@
+redefining
+cleanRedefinedGarbage
+	"We should remove here all obsolete annotations which not exist in cache anymore.
+	It can happen for several reasons: 
+		- annotation method was removed.
+		- annotated class was removed
+		- and various changes related to class hierarchy"	
+	redefinedInstances ifNil: [ ^self].
+	
+	(redefinedInstances select: [ :each | each isObsolete ])
+		do: [ :each | redefinedInstances removeKey: each ]

--- a/ClassAnnotation.package/ClassAnnotation.class/class/isInstanceRedefined..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/isInstanceRedefined..st
@@ -1,0 +1,6 @@
+redefining
+isInstanceRedefined: aClassAnnotation
+
+	redefinedInstances ifNil: [ ^false ].
+	
+	^redefinedInstances includesKey: aClassAnnotation	

--- a/ClassAnnotation.package/ClassAnnotation.class/class/isInstanceRedefined..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/isInstanceRedefined..st
@@ -1,4 +1,4 @@
-redefining
+testing
 isInstanceRedefined: aClassAnnotation
 
 	redefinedInstances ifNil: [ ^false ].

--- a/ClassAnnotation.package/ClassAnnotation.class/class/isInstanceRegistered..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/isInstanceRegistered..st
@@ -1,0 +1,4 @@
+testing
+isInstanceRegistered: aClassAnnotation
+
+	^self registry includesAnnotation: aClassAnnotation

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
@@ -3,6 +3,7 @@ redefineInstance: aClassAnnotation by: aBlock
 	| redefined |
 	redefinedInstances ifNil: [ redefinedInstances := Dictionary new ].
 	
-	redefined := redefinedInstances removeKey: aClassAnnotation ifAbsent: [ aClassAnnotation copy ].
+	redefined := redefinedInstances 
+		removeKey: aClassAnnotation ifAbsent: [ aClassAnnotation asRedefinedInstance ].
 	redefinedInstances at: aClassAnnotation put: redefined.
 	aBlock cull: aClassAnnotation

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
@@ -1,7 +1,8 @@
 redefining
 redefineInstance: aClassAnnotation by: aBlock
+	| redefined |
 	redefinedInstances ifNil: [ redefinedInstances := Dictionary new ].
 	
-	redefinedInstances removeKey: aClassAnnotation ifAbsent: [  ].
-	redefinedInstances at: aClassAnnotation put: aClassAnnotation copy.
+	redefined := redefinedInstances removeKey: aClassAnnotation ifAbsent: [ aClassAnnotation copy ].
+	redefinedInstances at: aClassAnnotation put: redefined.
 	aBlock value

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
@@ -1,10 +1,7 @@
 redefining
 redefineInstance: aClassAnnotation by: aBlock
-	"In case when instance is already redefined 
-	the dictionary will just put new instance into existing key which is riginal annotation instance.
-	Otherwise origin annotation instance (the copy) will be saved in the key.
-	Annotations use annotated class and selector as identity properties"
 	redefinedInstances ifNil: [ redefinedInstances := Dictionary new ].
 	
-	redefinedInstances at: aClassAnnotation copy put: aClassAnnotation.
+	redefinedInstances removeKey: aClassAnnotation ifAbsent: [  ].
+	redefinedInstances at: aClassAnnotation put: aClassAnnotation copy.
 	aBlock value

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
@@ -5,4 +5,4 @@ redefineInstance: aClassAnnotation by: aBlock
 	
 	redefined := redefinedInstances removeKey: aClassAnnotation ifAbsent: [ aClassAnnotation copy ].
 	redefinedInstances at: aClassAnnotation put: redefined.
-	aBlock value
+	aBlock cull: aClassAnnotation

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefineInstance.by..st
@@ -1,0 +1,10 @@
+redefining
+redefineInstance: aClassAnnotation by: aBlock
+	"In case when instance is already redefined 
+	the dictionary will just put new instance into existing key which is riginal annotation instance.
+	Otherwise origin annotation instance (the copy) will be saved in the key.
+	Annotations use annotated class and selector as identity properties"
+	redefinedInstances ifNil: [ redefinedInstances := Dictionary new ].
+	
+	redefinedInstances at: aClassAnnotation copy put: aClassAnnotation.
+	aBlock value

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefinedInstanceFor..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefinedInstanceFor..st
@@ -1,0 +1,8 @@
+redefining
+redefinedInstanceFor: aClassAnnotation
+	"It returnes the annotation instance which redefines given default collected annotation"
+	
+	redefinedInstances ifNil: [ ^self error: 'Given annotation is not redefined!' ].
+	
+	^redefinedInstances 
+		at: aClassAnnotation ifAbsent: [ self error: 'Given annotation is not redefined!' ]

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefinedInstanceFor..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefinedInstanceFor..st
@@ -1,7 +1,6 @@
 redefining
 redefinedInstanceFor: aClassAnnotation
-	"It returnes the annotation instance which redefines given default collected annotation"
-	
+	"It returnes the annotation instance which is redefined by given annotation"	
 	redefinedInstances ifNil: [ ^self error: 'Given annotation is not redefined!' ].
 	
 	^redefinedInstances 

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefinedInstances.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefinedInstances.st
@@ -1,3 +1,5 @@
 redefining
 redefinedInstances
+	self cleanRedefinedGarbage.
+	
 	^redefinedInstances ifNil: [ #() ]

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefinedInstances.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefinedInstances.st
@@ -1,0 +1,3 @@
+redefining
+redefinedInstances
+	^redefinedInstances ifNil: [ #() ]

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefiningInstanceFor..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefiningInstanceFor..st
@@ -1,0 +1,8 @@
+redefining
+redefiningInstanceFor: aClassAnnotation
+	"It returnes the annotation instance which redefines given default collected annotation"
+	
+	redefinedInstances ifNil: [ ^self error: 'Given annotation is not redefined!' ].
+	
+	^redefinedInstances 
+		at: aClassAnnotation ifAbsent: [ self error: 'Given annotation is not redefined!' ]

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefiningInstanceFor..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefiningInstanceFor..st
@@ -2,7 +2,9 @@ redefining
 redefiningInstanceFor: aClassAnnotation
 	"It returnes the annotation instance which redefines given default collected annotation"
 	
+	| assoc |
 	redefinedInstances ifNil: [ ^self error: 'Given annotation is not redefined!' ].
 	
-	^redefinedInstances 
-		at: aClassAnnotation ifAbsent: [ self error: 'Given annotation is not redefined!' ]
+	assoc := redefinedInstances 
+		associationAt: aClassAnnotation ifAbsent: [ self error: 'Given annotation is not redefined!' ].
+	^assoc key

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefiningInstances.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefiningInstances.st
@@ -1,0 +1,5 @@
+redefining
+redefiningInstances
+	^redefinedInstances 
+		ifNil: [ #() ]
+		ifNotNil: [ redefinedInstances keys ]

--- a/ClassAnnotation.package/ClassAnnotation.class/class/redefiningInstances.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/redefiningInstances.st
@@ -1,5 +1,5 @@
 redefining
 redefiningInstances
-	^redefinedInstances 
-		ifNil: [ #() ]
-		ifNotNil: [ redefinedInstances keys ]
+	redefinedInstances ifNil: [ ^#() ].
+	
+	^self redefinedInstances keys

--- a/ClassAnnotation.package/ClassAnnotation.class/class/resetCache.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/resetCache.st
@@ -1,4 +1,4 @@
 private
-resetAll
+resetCache
 	<script>
 	ClassAnnotationRegistry reset 

--- a/ClassAnnotation.package/ClassAnnotation.class/class/resetRedefiningInstances.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/resetRedefiningInstances.st
@@ -1,0 +1,5 @@
+redefining
+resetRedefiningInstances
+	
+	redefinedInstances := nil.
+	self resetCache

--- a/ClassAnnotation.package/ClassAnnotation.class/class/revertRedefinedInstanceFor..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/revertRedefinedInstanceFor..st
@@ -1,0 +1,6 @@
+redefining
+revertRedefinedInstanceFor: aClassAnnotation
+	redefinedInstances ifNil: [ ^self].
+	
+	redefinedInstances removeKey: aClassAnnotation ifAbsent: [  ].
+	self resetCache

--- a/ClassAnnotation.package/ClassAnnotation.class/class/revertRedefinedInstances.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/revertRedefinedInstances.st
@@ -1,5 +1,5 @@
 redefining
-resetRedefiningInstances
+revertRedefinedInstances
 	
 	redefinedInstances := nil.
 	self resetCache

--- a/ClassAnnotation.package/ClassAnnotation.class/class/updateRedefinedInstance..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/class/updateRedefinedInstance..st
@@ -1,0 +1,13 @@
+redefining
+updateRedefinedInstance: aClassAnnotation
+	"It updates actual redefined instance of annotation.
+	It sets given annotation as new value.
+	Both redefined and redefining annotations are equal. 
+	So dictionary value can be used as a key"
+	
+	redefinedInstances ifNil: [ ^self error: 'Given annotation is not redefined!' ].
+	
+	redefinedInstances 
+		at: aClassAnnotation ifAbsent: [ self error: 'Given annotation is not redefined!' ].
+	
+	redefinedInstances at: aClassAnnotation put: aClassAnnotation

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/asRedefinedInstance.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/asRedefinedInstance.st
@@ -1,0 +1,5 @@
+redefining
+asRedefinedInstance
+	"it is a hook method to allow subclasses copy extra state if needed 
+	to keep redefined instance in safe"
+	^self copy

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/id.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/id.st
@@ -1,0 +1,3 @@
+accessing
+id
+	^annotatedClass name, '>>', declarationSelector

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/isObsolete.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/isObsolete.st
@@ -1,0 +1,4 @@
+testing
+isObsolete
+
+	^(self class isInstanceRegistered: self) not

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/isRedefined.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/isRedefined.st
@@ -1,0 +1,3 @@
+testing
+isRedefined
+	^self class isInstanceRedefined: self

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/redefineBy..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/redefineBy..st
@@ -1,0 +1,4 @@
+redefining
+redefineBy: modifierBlock
+
+	^self class redefineInstance: self by: modifierBlock

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/redefinedInstance.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/redefinedInstance.st
@@ -1,0 +1,4 @@
+redefining
+redefinedInstance
+
+	^self class redefinedInstanceFor: self

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/redefiningInstance.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/redefiningInstance.st
@@ -1,4 +1,4 @@
-accessing
+redefining
 redefiningInstance
 
 	^self class redefiningInstanceFor: self

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/redefiningInstance.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/redefiningInstance.st
@@ -1,0 +1,4 @@
+accessing
+redefiningInstance
+
+	^self class redefiningInstanceFor: self

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/revertRedefinedInstance.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/revertRedefinedInstance.st
@@ -1,4 +1,5 @@
 redefining
 revertRedefinedInstance
 
-	self class revertRedefinedInstanceFor: self
+	^self revertRedefinedInstanceIfAbsent: [
+		self error: 'Redefined annotation not exists anymore!']

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/revertRedefinedInstance.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/revertRedefinedInstance.st
@@ -1,0 +1,4 @@
+redefining
+revertRedefinedInstance
+
+	self class revertRedefinedInstanceFor: self

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/revertRedefinedInstanceIfAbsent..st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/revertRedefinedInstanceIfAbsent..st
@@ -1,0 +1,6 @@
+redefining
+revertRedefinedInstanceIfAbsent: absentBlock
+
+	self class revertRedefinedInstanceFor: self.
+	^annotatedClass classAnnotations 
+		detect: [ :each | each = self ] ifNone: absentBlock.

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/updateRedefinedInstance.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/updateRedefinedInstance.st
@@ -1,4 +1,4 @@
 redefining
 updateRedefinedInstance
 
-	^self class updateRedefinedInstance: self
+	self class updateRedefinedInstance: self

--- a/ClassAnnotation.package/ClassAnnotation.class/instance/updateRedefinedInstance.st
+++ b/ClassAnnotation.package/ClassAnnotation.class/instance/updateRedefinedInstance.st
@@ -1,0 +1,4 @@
+redefining
+updateRedefinedInstance
+
+	^self class updateRedefinedInstance: self

--- a/ClassAnnotation.package/ClassAnnotation.class/properties.json
+++ b/ClassAnnotation.package/ClassAnnotation.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "DenisKudryashov 2/12/2018 10:45",
+	"commentStamp" : "DenisKudryashov 3/2/2018 14:15",
 	"super" : "Object",
 	"category" : "ClassAnnotation",
 	"classinstvars" : [

--- a/ClassAnnotation.package/ClassAnnotation.class/properties.json
+++ b/ClassAnnotation.package/ClassAnnotation.class/properties.json
@@ -2,7 +2,9 @@
 	"commentStamp" : "DenisKudryashov 2/12/2018 10:45",
 	"super" : "Object",
 	"category" : "ClassAnnotation",
-	"classinstvars" : [ ],
+	"classinstvars" : [
+		"redefinedInstances"
+	],
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [

--- a/ClassAnnotation.package/ClassAnnotationRegistry.class/instance/addAnnotation..st
+++ b/ClassAnnotation.package/ClassAnnotationRegistry.class/instance/addAnnotation..st
@@ -1,8 +1,11 @@
 accessing
 addAnnotation: aClassAnnotation
 	| container actualAnnotation |
-	actualAnnotation := aClassAnnotation isRedefined 
-		ifTrue: [ aClassAnnotation redefiningInstance] ifFalse: [ aClassAnnotation].
+	actualAnnotation := aClassAnnotation.
+	actualAnnotation isRedefined ifTrue: [
+		actualAnnotation updateRedefinedInstance.
+		actualAnnotation := actualAnnotation redefiningInstance].
+	
 	container := annotations at: actualAnnotation class ifAbsentPut: [ 
 		aClassAnnotation class createContainerForRegistry ].
 	(container includes: actualAnnotation) ifTrue: [ ^self ].

--- a/ClassAnnotation.package/ClassAnnotationRegistry.class/instance/addAnnotation..st
+++ b/ClassAnnotation.package/ClassAnnotationRegistry.class/instance/addAnnotation..st
@@ -1,11 +1,13 @@
 accessing
 addAnnotation: aClassAnnotation
-	| container |
-	container := annotations at: aClassAnnotation class ifAbsentPut: [ 
+	| container actualAnnotation |
+	actualAnnotation := aClassAnnotation isRedefined 
+		ifTrue: [ aClassAnnotation redefiningInstance] ifFalse: [ aClassAnnotation].
+	container := annotations at: actualAnnotation class ifAbsentPut: [ 
 		aClassAnnotation class createContainerForRegistry ].
-	(container includes: aClassAnnotation) ifTrue: [ ^self ].
-	container add: aClassAnnotation.
+	(container includes: actualAnnotation) ifTrue: [ ^self ].
+	container add: actualAnnotation.
 
 	container := annotatedClasses 
-		at: aClassAnnotation annotatedClass ifAbsentPut: [ Set new].
-	container add: aClassAnnotation	
+		at: actualAnnotation annotatedClass ifAbsentPut: [ Set new].
+	container add: actualAnnotation	

--- a/ClassAnnotation.package/ClassAnnotationRegistry.class/instance/forgetAnnotation..st
+++ b/ClassAnnotation.package/ClassAnnotationRegistry.class/instance/forgetAnnotation..st
@@ -1,0 +1,9 @@
+accessing
+forgetAnnotation: aClassAnnotation
+	"This test was created for tests to emulate that annotation not exist anymore"
+	| container |
+
+	container := annotations at: aClassAnnotation class ifAbsent: [ ^self ].
+	container remove: aClassAnnotation ifAbsent: [ ^self ].
+	
+	(annotatedClasses at: aClassAnnotation annotatedClass) remove: aClassAnnotation

--- a/ClassAnnotation.package/ClassAnnotationRegistry.class/instance/includesAnnotation..st
+++ b/ClassAnnotation.package/ClassAnnotationRegistry.class/instance/includesAnnotation..st
@@ -1,0 +1,6 @@
+testing
+includesAnnotation: aClassAnnotation
+
+	| allClassAnnotations |
+	allClassAnnotations := annotatedClasses at: aClassAnnotation annotatedClass ifAbsent: [ ^false ].
+	^allClassAnnotations includes: aClassAnnotation


### PR DESCRIPTION
Redefined annotations are implemented:- anAnnotation redefineBy: []- anAnnotationClass redefinedInstancesRedefined anotations allow to modify annotation instances collected from methods and keep this state after cache update.It is a key feature to manager annotations in settings browser.For exampe Commander provides settings for all shortcuts in system. They are available directly in system settings browser.(shortcuts are managed by annotating commands with CmdShortcutCommandActivation)